### PR TITLE
Fix some issues with SoftPower in the CLI

### DIFF
--- a/pluma/cli/targetconfig.py
+++ b/pluma/cli/targetconfig.py
@@ -38,7 +38,7 @@ class TargetConfig:
             log.warning("No console defined in the device configuration file")
 
         power = TargetFactory.create_power_control(
-            config.pop('power'), ssh)
+            config.pop('power'), ssh or serial)
 
         config.ensure_consumed()
 

--- a/pluma/cli/targetconfig.py
+++ b/pluma/cli/targetconfig.py
@@ -196,7 +196,9 @@ class TargetFactory:
                 raise TargetConfigError(
                     'No console available for soft power control')
 
-            power = SoftPower(console)
+            on_cmd = power_config.pop('on_cmd')
+            off_cmd = power_config.pop('off_cmd')
+            power = SoftPower(console, on_cmd=on_cmd, off_cmd=off_cmd)
 
         elif control_type == POWER_IPPOWER9258:
             host = power_config.pop('host')

--- a/tests/generic/cli/test_TargetConfig.py
+++ b/tests/generic/cli/test_TargetConfig.py
@@ -19,6 +19,12 @@ def test_TargetConfig_create_context_should_error_on_unconsumed(target_config):
         TargetConfig.create_context(Configuration(invalid_config))
 
 
+def test_TargetConfig_create_context_passes_serial_console_to_create_power_control(serial_config):
+    config = Configuration({'console': {'serial': serial_config}})
+    context = TargetConfig.create_context(config)
+    assert context.board.power is not None
+
+
 def test_TargetFactory_parse_credentials():
     login = 'abc'
     password = 'def'

--- a/tests/generic/cli/test_TargetConfig.py
+++ b/tests/generic/cli/test_TargetConfig.py
@@ -159,3 +159,20 @@ def test_TargetFactory_parse_variables_should_allow_variables_access():
                                                                               var2: var2_value}))
     assert variables.get(var1) == var1_value
     assert variables.get(var2) == var2_value
+
+
+def test_TargetFactory_SoftPower_parameters_can_be_specified(mock_console):
+    on_cmd = 'foo'
+    off_cmd = 'bar'
+
+    config = Configuration({
+        'soft': {
+            'on_cmd': on_cmd,
+            'off_cmd': off_cmd
+        }
+    })
+    power = TargetFactory.create_power_control(config, mock_console)
+
+    assert isinstance(power, SoftPower)
+    assert power.on_cmd == on_cmd
+    assert power.off_cmd == off_cmd


### PR DESCRIPTION
- `SoftPower` couldn't be used through the CLI with a serial console as `TargetFactory.create_power_control` was only ever passed the SSH console;
- There was no way to specify the `on_cmd` and `off_cmd` for a `SoftPower` power control, so it couldn't actually be used to control anything.