### PR TITLE
Add failing test to expose bug in OsFile test utility class

### DIFF
--- a/tests/generic/core/test_PexpectEngine.py
+++ b/tests/generic/core/test_PexpectEngine.py
@@ -23,6 +23,16 @@ def test_PexpectEngine_open_fd_should_succeed(pty_pair):
     assert engine.is_open
 
 
+def test_PexpectEngine_send_write_content(pty_pair):
+    sent = 'Hello'
+    engine = PexpectEngine()
+    engine.open(console_fd=pty_pair.main.fd)
+
+    engine.send(sent)
+
+    assert pty_pair.secondary.read(timeout=0.5) == sent
+
+
 def test_PexpectEngine_send_line_write_content_and_line_break(pty_pair):
     sent = 'abcdef'
     engine = PexpectEngine()


### PR DESCRIPTION
A bug was found where if PexpectEngine() was opened with a pseudo terminal
file descriptior (from conftest.pty_pair & OsFile), data sent to the primary
pty is not readable on the sencond pty unless a newline is also sent.

The test exposes this bug by using the engine.send() method rather than
engine.send_line().
I've done additional testing outside of this in the python repl and found
that it is indeed the case that the following does not work:

```python
>>> import os
>>> import pty

>>> fst, snd = pty.openpty()
>>> os.write(fst, b'Hello\n')
6

# This bit works, note the newline on the string written
>>> os.read(snd, 6)                                                                                  │
b'Hello\n'

>>> os.write(fst, b'Hello')
5

>>> os.read(snd, 5)
# Hangs forever waiting for data to read
```