### PR TITLE
Refactor pluma to allow yaml string configs

### DIFF
--- a/pluma/__main__.py
+++ b/pluma/__main__.py
@@ -102,8 +102,9 @@ def main():
         command = args.command
 
         if command in [RUN_COMMAND, CHECK_COMMAND, TESTS_COMMAND]:
-            pluma_context, tests_config = Pluma.create_context_from_files(tests_config_path,
-                                                                          target_config_path)
+            env_vars = dict(os.environ)
+            pluma_context, tests_config = Pluma.create_context_from_files(
+                tests_config_path, target_config_path, env_vars)
 
             if command == RUN_COMMAND:
                 success = Pluma.execute_run(pluma_context, tests_config)

--- a/pluma/__main__.py
+++ b/pluma/__main__.py
@@ -100,14 +100,20 @@ def main():
 
     try:
         command = args.command
-        if command == RUN_COMMAND:
-            success = Pluma.execute_run(tests_config_path, target_config_path)
-            exit(0 if success else 1)
-        elif command == CHECK_COMMAND:
-            Pluma.execute_run(tests_config_path, target_config_path,
-                              check_only=True)
-        elif command == TESTS_COMMAND:
-            Pluma.execute_tests(tests_config_path, target_config_path)
+
+        if command in [RUN_COMMAND, CHECK_COMMAND, TESTS_COMMAND]:
+            pluma_context, tests_config = Pluma.create_context_from_files(tests_config_path,
+                                                                          target_config_path)
+
+            if command == RUN_COMMAND:
+                success = Pluma.execute_run(pluma_context, tests_config)
+                exit(0 if success else 1)
+            elif command == CHECK_COMMAND:
+                Pluma.execute_run(pluma_context, tests_config,
+                                check_only=True)
+            elif command == TESTS_COMMAND:
+                Pluma.execute_tests(tests_config_path)
+
         elif command == CLEAN_COMMAND:
             Pluma.execute_clean(args.force)
         elif command == VERSION_COMMAND:

--- a/pluma/cli/api.py
+++ b/pluma/cli/api.py
@@ -99,6 +99,26 @@ class Pluma:
         return config
 
     @staticmethod
+    def create_context_from_yaml_strs(tests_config_yaml: str, target_config_yaml: str,
+                                      substitute_vars: Optional[Dict[str, Any]] = None
+                                      ) -> Tuple[PlumaContext, TestsConfig]:
+        substitute_vars = substitute_vars or {}
+        target_config_opts = Pluma.load_config_yaml(target_config_yaml, 'Target config', substitute_vars)
+        context = Pluma.create_target_context(target_config_opts, substitute_vars)
+        tests_config_opts = Pluma.load_config_yaml(tests_config_yaml, 'Tests config', context.variables)
+        tests_config = Pluma.create_tests_config(tests_config_opts, context)
+
+        return context, tests_config
+
+    @staticmethod
+    def load_config_yaml(yaml_str: str, name: str, extra_vars: Optional[Dict[str, Any]] = {}
+                        )-> Configuration:
+        log.debug(f'Parsing {name} yaml string...')
+        config = PlumaConfig.load_configuration_yaml(name, yaml_str,
+                                                     PlumaConfigPreprocessor(extra_vars))
+        return config
+
+    @staticmethod
     def create_target_context(target_config: Configuration, substitute_values: Dict[str, Any]
                              ) -> PlumaContext:
         context = TargetConfig.create_context(target_config)

--- a/pluma/cli/config.py
+++ b/pluma/cli/config.py
@@ -181,7 +181,7 @@ class ConfigPreprocessor(ABC):
 
 class PlumaConfig:
     @staticmethod
-    def load_configuration(name: str, config_path: str,
+    def load_configuration_file(name: str, config_path: str,
                            preprocessor: ConfigPreprocessor = None) -> Configuration:
         return Configuration(PlumaConfig.load_yaml(name, config_path, preprocessor))
 

--- a/pluma/cli/config.py
+++ b/pluma/cli/config.py
@@ -1,7 +1,7 @@
 import yaml
 import json
 import os
-from typing import Optional, List, TypeVar, Type, Union, overload, cast
+from typing import Any, Dict, Optional, List, TypeVar, Type, Union, overload, cast
 from abc import ABC, abstractmethod
 from yaml.parser import ParserError
 
@@ -182,27 +182,39 @@ class ConfigPreprocessor(ABC):
 class PlumaConfig:
     @staticmethod
     def load_configuration_file(name: str, config_path: str,
-                           preprocessor: ConfigPreprocessor = None) -> Configuration:
-        return Configuration(PlumaConfig.load_yaml(name, config_path, preprocessor))
+                           preprocessor: Optional[ConfigPreprocessor] = None) -> Configuration:
+        return Configuration(PlumaConfig.load_yaml_file(name, config_path, preprocessor))
 
     @staticmethod
-    def load_yaml(name: str, yaml_file_path: str,
-                  preprocessor: ConfigPreprocessor = None) -> dict:
+    def load_configuration_yaml(name: str, config_yaml: str,
+                           preprocessor: Optional[ConfigPreprocessor] = None) -> Configuration:
+        return Configuration(PlumaConfig.load_yaml_str(name, config_yaml, preprocessor))
+
+    @staticmethod
+    def load_yaml_file(name: str, yaml_file_path: str,
+                       preprocessor: Optional[ConfigPreprocessor] = None) -> Dict[str, Any]:
         try:
             with open(yaml_file_path, 'r') as config:
                 content = config.read()
-                if preprocessor:
-                    content = preprocessor.preprocess(content)
-
-                return yaml.load(content, Loader=yaml.FullLoader)
+                return PlumaConfig.load_yaml_str(name, content, preprocessor)
         except FileNotFoundError as e:
             raise ConfigurationError(
                 f'{name} "{yaml_file_path}" does not exist') from e
-        except ParserError as e:
-            raise ConfigurationError(
-                f'Error while parsing {name} "{yaml_file_path}":'
-                f'{os.linesep}{e}') from e
         except Exception as e:
             raise ConfigurationError(
-                f'An error occurred while opening/parsing {name} "{yaml_file_path}":'
+                f'An error occurred while opening {name} "{yaml_file_path}":'
+                f'{os.linesep}{e}') from e
+
+    @staticmethod
+    def load_yaml_str(name: str, yaml_str: str,
+                      preprocessor: Optional[ConfigPreprocessor] = None) -> Dict[str, Any]:
+        try:
+            content = yaml_str
+            if preprocessor:
+                content = preprocessor.preprocess(content)
+
+            return yaml.load(content, Loader=yaml.FullLoader)
+        except (ParserError, Exception) as e:
+            raise ConfigurationError(
+                f'An error occurred while parsing {name} yaml:'
                 f'{os.linesep}{e}') from e

--- a/tests/generic/cli/test_Pluma.py
+++ b/tests/generic/cli/test_Pluma.py
@@ -17,7 +17,8 @@ def config_file_path(config: str):
 def run_all(test_file: str, target_file: str):
     test_file_path = path.join(config_file_path(test_file))
     target_file_path = path.join(config_file_path(target_file))
-    context, config = Pluma.create_context_from_files(test_file_path, target_file_path)
+    env_vars = dict(os.environ)
+    context, config = Pluma.create_context_from_files(test_file_path, target_file_path, env_vars)
 
     Pluma.execute_tests(config)
     Pluma.execute_run(context, config, check_only=True)
@@ -26,7 +27,8 @@ def run_all(test_file: str, target_file: str):
 def test_Pluma_create_context_from_files():
     test_file_path = config_file_path('minimal-tests')
     target_file_path = config_file_path('minimal-target')
-    context, config = Pluma.create_context_from_files(test_file_path, target_file_path)
+    env_vars = dict(os.environ)
+    context, config = Pluma.create_context_from_files(test_file_path, target_file_path, env_vars)
 
     assert isinstance(context, PlumaContext)
     assert isinstance(config, TestsConfig)

--- a/tests/generic/cli/test_Pluma.py
+++ b/tests/generic/cli/test_Pluma.py
@@ -33,14 +33,16 @@ def test_Pluma_target_variables_substitution():
 
 
 def test_Pluma_create_target_context_should_parse_target_variables():
-    context = Pluma.create_target_context(config_file_path('variable-sub-target'))
+    config, env = Pluma.load_target_config_file(config_file_path('variable-sub-target'))
+    context = Pluma.create_target_context(config, env)
     assert context.variables['mymessage'] == 'echo hello script!'
 
 
 def test_Pluma_create_target_context_variables_should_reflect_env_vars(monkeypatch):
     monkeypatch.setenv('abc', 'def')
 
-    context = Pluma.create_target_context(config_file_path('minimal-target'))
+    config, env = Pluma.load_target_config_file(config_file_path('minimal-target'))
+    context = Pluma.create_target_context(config, env)
 
     assert context.variables['abc'] == 'def'
 
@@ -48,7 +50,8 @@ def test_Pluma_create_target_context_variables_should_reflect_env_vars(monkeypat
 def test_Pluma_create_target_context_env_vars_should_override_target_variables(monkeypatch):
     monkeypatch.setenv('mymessage', 'env message')
 
-    context = Pluma.create_target_context(config_file_path('variable-sub-target'))
+    config, env = Pluma.load_target_config_file(config_file_path('variable-sub-target'))
+    context = Pluma.create_target_context(config, env)
 
     assert context.variables['mymessage'] == 'env message'
 
@@ -56,7 +59,9 @@ def test_Pluma_create_target_context_env_vars_should_override_target_variables(m
 def test_Pluma_create_target_context_should_warn_if_variable_overwritten_by_env(capsys, monkeypatch):
     monkeypatch.setenv('mymessage', 'env message')
 
-    Pluma.create_target_context(config_file_path('variable-sub-target'))
+    config, env = Pluma.load_target_config_file(config_file_path('variable-sub-target'))
+    Pluma.create_target_context(config, env)
+
     stdout = capsys.readouterr().out
 
     assert f'"mymessage" defined in both environment variables and target config.{os.linesep}    Using environment: env message' in stdout

--- a/tests/generic/cli/test_Pluma.py
+++ b/tests/generic/cli/test_Pluma.py
@@ -1,5 +1,7 @@
 from os import path
 import os
+from pluma.cli.testsconfig import TestsConfig
+from pluma.cli.plumacontext import PlumaContext
 import pytest
 
 from pluma.cli import Pluma, ConfigurationError, TestsConfigError, TargetConfigError
@@ -19,6 +21,15 @@ def run_all(test_file: str, target_file: str):
 
     Pluma.execute_tests(config)
     Pluma.execute_run(context, config, check_only=True)
+
+
+def test_Pluma_create_context_from_files():
+    test_file_path = config_file_path('minimal-tests')
+    target_file_path = config_file_path('minimal-target')
+    context, config = Pluma.create_context_from_files(test_file_path, target_file_path)
+
+    assert isinstance(context, PlumaContext)
+    assert isinstance(config, TestsConfig)
 
 
 def test_Pluma_minimal():

--- a/tests/generic/cli/test_Pluma.py
+++ b/tests/generic/cli/test_Pluma.py
@@ -45,14 +45,20 @@ def test_Pluma_target_variables_substitution():
 
 
 def test_Pluma_create_target_context_should_parse_target_variables():
-    context = Pluma.create_target_context(config_file_path('variable-sub-target'))
+    env_vars = dict(os.environ)
+    config = Pluma.load_config_file(config_file_path('variable-sub-target'), 'Target Config',
+                                                     env_vars)
+    context = Pluma.create_target_context(config, env_vars)
     assert context.variables['mymessage'] == 'echo hello script!'
 
 
 def test_Pluma_create_target_context_variables_should_reflect_env_vars(monkeypatch):
     monkeypatch.setenv('abc', 'def')
 
-    context = Pluma.create_target_context(config_file_path('minimal-target'))
+    env_vars = dict(os.environ)
+    config = Pluma.load_config_file(config_file_path('minimal-target'), 'Target Config',
+                                                     env_vars)
+    context = Pluma.create_target_context(config, env_vars)
 
     assert context.variables['abc'] == 'def'
 
@@ -60,7 +66,10 @@ def test_Pluma_create_target_context_variables_should_reflect_env_vars(monkeypat
 def test_Pluma_create_target_context_env_vars_should_override_target_variables(monkeypatch):
     monkeypatch.setenv('mymessage', 'env message')
 
-    context = Pluma.create_target_context(config_file_path('variable-sub-target'))
+    env_vars = dict(os.environ)
+    config = Pluma.load_config_file(config_file_path('variable-sub-target'), 'Target Config',
+                                                     env_vars)
+    context = Pluma.create_target_context(config, env_vars)
 
     assert context.variables['mymessage'] == 'env message'
 
@@ -68,7 +77,11 @@ def test_Pluma_create_target_context_env_vars_should_override_target_variables(m
 def test_Pluma_create_target_context_should_warn_if_variable_overwritten_by_env(capsys, monkeypatch):
     monkeypatch.setenv('mymessage', 'env message')
 
-    Pluma.create_target_context(config_file_path('variable-sub-target'))
+    env_vars = dict(os.environ)
+    config = Pluma.load_config_file(config_file_path('variable-sub-target'), 'Target Config',
+                                                     env_vars)
+    Pluma.create_target_context(config, env_vars)
+
     stdout = capsys.readouterr().out
 
     assert f'"mymessage" defined in both environment variables and target config.{os.linesep}    Using environment: env message' in stdout

--- a/tests/generic/cli/test_Pluma.py
+++ b/tests/generic/cli/test_Pluma.py
@@ -15,9 +15,10 @@ def config_file_path(config: str):
 def run_all(test_file: str, target_file: str):
     test_file_path = path.join(config_file_path(test_file))
     target_file_path = path.join(config_file_path(target_file))
+    context, config = Pluma.create_context_from_files(test_file_path, target_file_path)
 
-    Pluma.execute_tests(test_file_path, target_file_path)
-    Pluma.execute_run(test_file_path, target_file_path, check_only=True)
+    Pluma.execute_tests(config)
+    Pluma.execute_run(context, config, check_only=True)
 
 
 def test_Pluma_minimal():
@@ -33,16 +34,14 @@ def test_Pluma_target_variables_substitution():
 
 
 def test_Pluma_create_target_context_should_parse_target_variables():
-    config, env = Pluma.load_target_config_file(config_file_path('variable-sub-target'))
-    context = Pluma.create_target_context(config, env)
+    context = Pluma.create_target_context(config_file_path('variable-sub-target'))
     assert context.variables['mymessage'] == 'echo hello script!'
 
 
 def test_Pluma_create_target_context_variables_should_reflect_env_vars(monkeypatch):
     monkeypatch.setenv('abc', 'def')
 
-    config, env = Pluma.load_target_config_file(config_file_path('minimal-target'))
-    context = Pluma.create_target_context(config, env)
+    context = Pluma.create_target_context(config_file_path('minimal-target'))
 
     assert context.variables['abc'] == 'def'
 
@@ -50,8 +49,7 @@ def test_Pluma_create_target_context_variables_should_reflect_env_vars(monkeypat
 def test_Pluma_create_target_context_env_vars_should_override_target_variables(monkeypatch):
     monkeypatch.setenv('mymessage', 'env message')
 
-    config, env = Pluma.load_target_config_file(config_file_path('variable-sub-target'))
-    context = Pluma.create_target_context(config, env)
+    context = Pluma.create_target_context(config_file_path('variable-sub-target'))
 
     assert context.variables['mymessage'] == 'env message'
 
@@ -59,9 +57,7 @@ def test_Pluma_create_target_context_env_vars_should_override_target_variables(m
 def test_Pluma_create_target_context_should_warn_if_variable_overwritten_by_env(capsys, monkeypatch):
     monkeypatch.setenv('mymessage', 'env message')
 
-    config, env = Pluma.load_target_config_file(config_file_path('variable-sub-target'))
-    Pluma.create_target_context(config, env)
-
+    Pluma.create_target_context(config_file_path('variable-sub-target'))
     stdout = capsys.readouterr().out
 
     assert f'"mymessage" defined in both environment variables and target config.{os.linesep}    Using environment: env message' in stdout

--- a/tests/generic/cli/test_Pluma.py
+++ b/tests/generic/cli/test_Pluma.py
@@ -27,8 +27,19 @@ def run_all(test_file: str, target_file: str):
 def test_Pluma_create_context_from_files():
     test_file_path = config_file_path('minimal-tests')
     target_file_path = config_file_path('minimal-target')
-    env_vars = dict(os.environ)
-    context, config = Pluma.create_context_from_files(test_file_path, target_file_path, env_vars)
+    context, config = Pluma.create_context_from_files(test_file_path, target_file_path)
+
+    assert isinstance(context, PlumaContext)
+    assert isinstance(config, TestsConfig)
+
+
+def test_Pluma_create_context_from_yaml_strs():
+    with open(config_file_path('minimal-tests'), 'r') as f:
+        tests_yaml = f.read()
+    with open(config_file_path('minimal-target'), 'r') as f:
+        target_yaml = f.read()
+
+    context, config = Pluma.create_context_from_yaml_strs(tests_yaml, target_yaml)
 
     assert isinstance(context, PlumaContext)
     assert isinstance(config, TestsConfig)


### PR DESCRIPTION
Split this out from https://github.com/Witekio/pluma-automation/pull/201.
This work should be ready to merge, and I'd like to get it in before too many changes happen that make it stale while I work on the REST side of things.

This is purely a refactor to move the side effects (filesystem and environment reads) up to the highest level.
This paves the way to having a different user interface to the CLI running with little effort. 